### PR TITLE
Refactor: Overhaul tile selector panel

### DIFF
--- a/js/src/components/tile-selector.js
+++ b/js/src/components/tile-selector.js
@@ -7,29 +7,56 @@ const TILE_SELECTOR_STYLE = `
   #${TILE_SELECTOR_ID} {
     position: absolute;
     top: 10px;
-    right: 10px;
+    left: 10px;
     padding: 10px;
-    max-height: 80vh;
+    max-height: 95vh;
     overflow-y: auto;
     z-index: 2;
-    width: 250px;
-    max-width: 250px;
-    background-color: rgba(255, 255, 255, 0.05);
-    backdrop-filter: blur(64px);
-    border: 1px solid #343740;
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-    transition: all 300ms;
-    color: white;
-    font-family: Arial, sans-serif;
+    width: 300px;
+    max-width: 300px;
+    background-color: #1f1f1f;
+    border: 1px solid #353535;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+    color: #eee;
+    font-family: 'Helvetica Neue', Arial, sans-serif;
+  }
+  #${TILE_SELECTOR_ID} h3 {
+    background-color: #000;
+    color: #aaa;
+    padding: 10px;
+    margin: -10px -10px 10px -10px;
+    font-weight: bold;
+    font-size: 14px;
+    cursor: pointer;
+  }
+  #${TILE_CONTAINER_ID} h4 {
+    color: #aaa;
+    font-weight: bold;
+    font-size: 12px;
+    margin-top: 20px;
+    margin-bottom: 10px;
+    border-bottom: 1px solid #353535;
+    padding-bottom: 5px;
   }
   #${TILE_CONTAINER_ID} .tile {
-    border: 1px solid #000;
+    border: 1px solid #353535;
     margin: 2px;
     cursor: pointer;
     display: inline-block;
   }
+  #${TILE_CONTAINER_ID} .tile:hover {
+    border-color: #555;
+  }
   #${TILE_CONTAINER_ID} .tile.selected {
-    border: 2px solid red;
+    border: 2px solid #0a84ff;
+  }
+  .resize-handle {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    width: 10px;
+    height: 10px;
+    cursor: se-resize;
   }
 `;
 
@@ -39,11 +66,37 @@ function createTileSelectorPanel() {
   panel.innerHTML = `
     <h3>Tiles</h3>
     <div id="${TILE_CONTAINER_ID}"></div>
+    <div class="resize-handle"></div>
   `;
   document.body.appendChild(panel);
+
   const style = document.createElement('style');
   style.innerHTML = TILE_SELECTOR_STYLE;
   document.head.appendChild(style);
+
+  const handle = panel.querySelector('.resize-handle');
+  let isResizing = false;
+
+  handle.addEventListener('mousedown', (e) => {
+    isResizing = true;
+    const startX = e.clientX;
+    const startWidth = parseInt(document.defaultView.getComputedStyle(panel).width, 10);
+
+    function doDrag(e) {
+      if (isResizing) {
+        panel.style.width = (startWidth + e.clientX - startX) + 'px';
+      }
+    }
+
+    function stopDrag() {
+      isResizing = false;
+      document.removeEventListener('mousemove', doDrag);
+      document.removeEventListener('mouseup', stopDrag);
+    }
+
+    document.addEventListener('mousemove', doDrag);
+    document.addEventListener('mouseup', stopDrag);
+  });
 }
 
 export function initTileSelector() {


### PR DESCRIPTION
This commit completely revamps the tile selector panel.

The panel has been moved to the left side of the screen and restyled to function as a sidebar, with a visual language that matches the main controls GUI.

The default size of the panel has been increased to be more useful, and a resize handle has been added to allow you to dynamically adjust the width of the panel. This provides a more flexible and user-friendly solution to the previous issue of the panel being too small.